### PR TITLE
Adding repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "vuepress",
     "tabs"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pskordilakis/vuepress-plugin-tabs.git"
+  },
   "license": "MIT",
   "main": "dist/vuepress-plugin-tabs.cjs.js",
   "module": "dist/vuepress-plugin-tabs.esm.js",


### PR DESCRIPTION
Adding a repo to package.json, so that a GitHub link shows up on NPM:

https://www.npmjs.com/package/vuepress-plugin-tabs

I'm not sure if anything else will need to be done for NPM to pick this change up