### PR TITLE
Add `tabsAttributes` to plugin options

### DIFF
--- a/dist/vuepress-plugin-tabs.cjs.js
+++ b/dist/vuepress-plugin-tabs.cjs.js
@@ -110,16 +110,31 @@ function tabsAttributes(val) {
   .trim().slice("tabs".length).trim();
 }
 
+function defaultTabsAttributes(attributes) {
+  var attributesString = [];
+  if (!attributes || Object.keys(attributes).length === 0) {
+    return '';
+  }
+
+  for (var key in attributes) {
+    var substring = ':' + key + '=\'' + JSON.stringify(attributes[key]) + '\'';
+    attributesString.push(substring);
+  }
+
+  return attributesString.join(' ');
+}
+
 var container = require('markdown-it-container');
 
-var tabs = (function (md) {
+var tabs = (function (md, options) {
   md.use(container, 'tabs', {
     render: function render(tokens, idx) {
       var token = tokens[idx];
+      var defaultAttributes = defaultTabsAttributes(options.tabsAttributes);
       var attributes = tabsAttributes(token.info);
 
       if (token.nesting === 1) {
-        return '<tabs ' + attributes + '>\n';
+        return '<tabs ' + defaultAttributes + ' ' + attributes + '>\n';
       } else {
         return '</tabs>\n';
       }
@@ -157,7 +172,7 @@ module.exports = function (opts) {
       content: 'import Tabs from \'vue-tabs-component\';export default ({ Vue }) => Vue.use(Tabs)'
     }],
     extendMarkdown: function extendMarkdown(md) {
-      tabs(md);
+      tabs(md, options);
       tab(md, options);
     }
   };

--- a/dist/vuepress-plugin-tabs.esm.js
+++ b/dist/vuepress-plugin-tabs.esm.js
@@ -108,16 +108,31 @@ function tabsAttributes(val) {
   .trim().slice("tabs".length).trim();
 }
 
+function defaultTabsAttributes(attributes) {
+  var attributesString = [];
+  if (!attributes || Object.keys(attributes).length === 0) {
+    return '';
+  }
+
+  for (var key in attributes) {
+    var substring = ':' + key + '=\'' + JSON.stringify(attributes[key]) + '\'';
+    attributesString.push(substring);
+  }
+
+  return attributesString.join(' ');
+}
+
 var container = require('markdown-it-container');
 
-var tabs = (function (md) {
+var tabs = (function (md, options) {
   md.use(container, 'tabs', {
     render: function render(tokens, idx) {
       var token = tokens[idx];
+      var defaultAttributes = defaultTabsAttributes(options.tabsAttributes);
       var attributes = tabsAttributes(token.info);
 
       if (token.nesting === 1) {
-        return '<tabs ' + attributes + '>\n';
+        return '<tabs ' + defaultAttributes + ' ' + attributes + '>\n';
       } else {
         return '</tabs>\n';
       }
@@ -155,7 +170,7 @@ module.exports = function (opts) {
       content: 'import Tabs from \'vue-tabs-component\';export default ({ Vue }) => Vue.use(Tabs)'
     }],
     extendMarkdown: function extendMarkdown(md) {
-      tabs(md);
+      tabs(md, options);
       tab(md, options);
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ module.exports = (opts) => {
       }
     ],
     extendMarkdown: md => {
-      tabs(md)
+      tabs(md, options)
       tab(md, options)
     }
   }

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -1,14 +1,15 @@
-import { tabsAttributes } from './util'
+import { tabsAttributes, defaultTabsAttributes } from './util'
 const container = require('markdown-it-container')
 
-export default md => {
+export default (md, options) => {
   md.use(container, 'tabs', {
     render: (tokens, idx) => {
       const token = tokens[idx]
+      const defaultAttributes = defaultTabsAttributes(options.tabsAttributes)
       const attributes = tabsAttributes (token.info)
 
       if (token.nesting === 1) {
-        return `<tabs ${attributes}>\n`
+        return `<tabs ${defaultAttributes} ${attributes}>\n`
       } else {
         return `</tabs>\n`
       }

--- a/src/util.js
+++ b/src/util.js
@@ -62,3 +62,17 @@ export function tabsAttributes(val) {
       .trim()
   );
 }
+
+export function defaultTabsAttributes(attributes) {
+  let attributesString = []
+  if (!attributes || Object.keys(attributes).length === 0) {
+    return ''
+  }
+
+  for (const key in attributes) {
+    const substring = `:${key}='${JSON.stringify(attributes[key])}'` 
+    attributesString.push(substring)
+  }
+
+  return attributesString.join(' ')
+}

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,4 +1,4 @@
-import { tabAttributes, tabsAttributes, dedupeId } from '../src/util'
+import { tabAttributes, tabsAttributes, dedupeId, defaultTabsAttributes } from '../src/util'
 
 describe('tabAttributes', () => {
   test('must handle sorthand name attributes', () => {
@@ -44,5 +44,18 @@ describe('dedupeId', () => {
     [...Array(5).keys()].map(i => i + 1).forEach(i => {
       expect(dedupeId('id')).toBe(`id-${i}`)
     });
+  })
+})
+
+describe('defaultTabsAttributes', () => {
+  test('must transform object to vue binded attributes', () => {
+    expect(
+      defaultTabsAttributes({ options: { foo: 'bar', bar: 123 }, baz: 123 })
+    ).toBe(':options=\'{"foo":"bar","bar":123}\' :baz=\'123\'')
+  })
+  test('must transform plain object to empty string', () => {
+    expect(
+      defaultTabsAttributes({})
+    ).toBe('')
   })
 })


### PR DESCRIPTION
This change is to add `tabsAttributes` to global plugin option. It would be useful when we want to config the default tabs attributes globally.

For example:

```js
// .vuepress/config.js
module.exports = {
    plugins: [
        [
            'vuepress-plugin-tabs',
            {
                tabsAttributes: {
                    options: {
                        useUrlFragment: false
                    }
                }
            }
        ]
    ]
}
```

Then all the `<tabs>` components will have `:options="{useUrlFragment: false}"` attribute by default.
